### PR TITLE
Refactor graph/tree traversal to iterative implementations

### DIFF
--- a/scott/structs/graph.py
+++ b/scott/structs/graph.py
@@ -441,7 +441,7 @@ class Graph :
 					#print("We will need to study permutations on %s" % (score_to_id[k]))
 					#permut.append(score_to_id[k])
 					permut.append(list(itertools.combinations(score_to_id[k], 2)))
-					 
+					
 
 			#print("PERMUT")
 			if len(permut) > 0:
@@ -546,9 +546,40 @@ class Graph :
 
 	def is_leaf(self, id_node: str) -> bool:
 		"""
-			is_leaf
+		is_leaf
 		"""
 		return self.degree(id_node) == 1
+
+	def iter_dfs(self, id_root: str):
+		"""
+		Depth-first traversal yielding Node objects
+		"""
+		visited = set()
+		stack = [id_root]
+		while stack:
+			nid = stack.pop()
+			if nid in visited:
+				continue
+			visited.add(nid)
+			yield self.V[nid]
+			for link in reversed(self.R.get(nid, [])):
+				stack.append(link["to"])
+
+	def iter_bfs(self, id_root: str):
+		"""
+		Breadth-first traversal yielding Node objects
+		"""
+		from collections import deque
+		visited = set()
+		queue = deque([id_root])
+		while queue:
+			nid = queue.popleft()
+			if nid in visited:
+				continue
+			visited.add(nid)
+			yield self.V[nid]
+			for link in self.R.get(nid, []):
+				queue.append(link["to"])
 
 	def is_floored(self) -> bool:
 		"""
@@ -612,7 +643,7 @@ class Graph :
 		# reset 
 		for id_node in self.V :
 			if meta_attr in self.V[id_node].meta :
-				 self.V[id_node].meta[meta_attr] = None
+				self.V[id_node].meta[meta_attr] = None
 		
 		connex_compound_index = 0
 
@@ -1003,13 +1034,13 @@ class Graph :
 		"""
 			fix_cobound
 			------------
-							  ( * )
-							 /
+							( * )
+							/
 		--( A )--		--( A )--
-		    |		=>
+		|		=>
 		--( B )--		--( B )--
-							 \
-							  ( * )
+							\
+							( * )
 
 		"""
 		edge = self.E[cobound_edge_id]
@@ -1273,39 +1304,47 @@ class Graph :
 			trace("magnet computed : %s" % (magnet), 3)
 			if allow_hashes : 
 				magnet = "_" + str(hashlib.md5(magnet.encode('utf-8')).hexdigest()) + "_"
-			
-			if "magnet" in self.V[id_node].meta : 
+			if "magnet" in self.V[id_node].meta :
 				self.V[id_node].meta["magnet"][str(self.meta['floored_by'])] = magnet
 			else :
 				self.V[id_node].meta["magnet"] = { str(self.meta['floored_by']) : magnet }
 			return magnet
 
-	def to_tree(self, id_root: str, id_origin: str = None, modality_origin: str = None, ids_ignore: List[str] = []) -> Tree:
-		"""
-			to_tree
-			--------
+	def to_tree_recursive(self, id_root: str, id_origin: str = None, modality_origin: str = None, ids_ignore: List[str] = []) -> Tree:
+               """Recursive version of ``to_tree`` kept for benchmarking."""
+               trace("building a tree rooted on %s (lvl %s), initiated by %s (lvl %s)" % (id_root, str(self.V[id_root].meta.get('floor')), id_origin, str(self.V[id_origin].meta.get('floor')) if id_origin is not None else "none"), 3)
+               if self.is_leaf(id_root) and id_origin is not None:
+                       return Tree(self.V[id_root], None, modality_origin)
+               else:
+                       ids_ignore.append(id_origin)
+                       ids_ignore = list(set(ids_ignore))
+                       children = [ (self.to_tree_recursive(id_root = link["to"], id_origin = id_root,  modality_origin = link["edge"].modality, ids_ignore = ids_ignore), link["edge"].modality)
+                                               for link in self.R[id_root]
+                                               if link["to"] != id_origin and not link["to"] in ids_ignore ]
+                       return Tree(self.V[id_root], children, modality_origin)
 
-			Translates an acyclic subgraph into an "agnostic" (unordered) neuwick tree form
-			A neuwick form is :
-				- node centered (root)
-				- which itself may have a "parent" (origin == "real-root")
-				- this origin is in all cases excluded from the writing
-				- this origin is generally the caller node
-				- a leaf is a tuple (label?, parent_modality_link)
-				- a non-leaf (branch) is a list of others branches/leafs
-		"""
-		#print("Root #" + id_root)
-		#print("Origin :" + str(id_origin))
-		#print("Ignore : " +str(ids_ignore))
-		trace("building a tree rooted on %s (lvl %s), initiated by %s (lvl %s)" % (id_root, str(self.V[id_root].meta.get('floor')), id_origin, str(self.V[id_origin].meta.get('floor')) if id_origin is not None else "none"), 3)
-		if self.is_leaf(id_root) and id_origin is not None:
-			# leaf
-			return Tree(self.V[id_root], None, modality_origin)
-		else :
-			ids_ignore.append(id_origin)
-			ids_ignore = list(set(ids_ignore))
-			children = [ (self.to_tree(id_root = link["to"], id_origin = id_root,  modality_origin = link["edge"].modality, ids_ignore = ids_ignore), link["edge"].modality)
-			 			for link in self.R[id_root]
-			 			if link["to"] != id_origin and not link["to"] in ids_ignore ]
-			#trace("tree rooted on %s, initied by %s ;  #children = %s" % (id_root, id_origin, str(len(children))), 3)
-			return Tree(self.V[id_root], children, modality_origin)
+	def to_tree(self, id_root: str, id_origin: str = None, modality_origin: str = None, ids_ignore: List[str] = []) -> Tree:
+               """Iterative DFS version of ``to_tree``."""
+               stack = [{"id": id_root, "parent": id_origin, "mod": modality_origin, "processed": False, "children": []}]
+               visited = set(ids_ignore)
+               result = None
+               while stack:
+                       frame = stack.pop()
+                       nid = frame["id"]
+                       if not frame["processed"]:
+                               frame["processed"] = True
+                               stack.append(frame)
+                               visited.add(nid)
+                               for link in reversed(self.R.get(nid, [])):
+                                       to = link["to"]
+                                       if to != frame["parent"] and not to in visited:
+                                               stack.append({"id": to, "parent": nid, "mod": link["edge"].modality, "processed": False, "children": []})
+                       else:
+                               children = frame["children"] if frame["children"] else None
+                               node_tree = Tree(self.V[nid], children, frame["mod"])
+                               if stack:
+                                       stack[-1]["children"].append((node_tree, frame["mod"]))
+                               else:
+                                       result = node_tree
+               return result
+

--- a/scott/structs/tree.py
+++ b/scott/structs/tree.py
@@ -204,49 +204,76 @@ class Tree :
 			return 1 + max([0] + [ child.depth() for (child, modality) in self.children ])
 
 
-	def enumerate_nodes(self, depth_max: int = -1, current_depth: int = 0) -> List[Tuple[Node, int]]:
-		"""
-			enumerate_nodes
-			---------------
-			Return a list of all nodes contained in self.
-				- depth_max : -1 if not important
-		"""
+	def enumerate_nodes_recursive(self, depth_max: int = -1, current_depth: int = 0) -> List[Tuple[Node, int]]:
+		"""Recursive version of ``enumerate_nodes`` kept for benchmarking."""
 		enum = [ (self.root, current_depth) ]
-
 		if not self.is_leaf() and depth_max != 0:
-			depth_max -= 1
-			for (child, modality) in self.children:
-				enum += child.enumerate_nodes(depth_max, current_depth + 1)
-
+		        depth_max -= 1
+		        for (child, modality) in self.children:
+		                enum += child.enumerate_nodes_recursive(depth_max, current_depth + 1)
 		return enum
 
 
-	def score_tree(self, fn: TreeScoring = def_tree_fn()) -> bool:
-		"""
-			score_tree
-			----------
-
-			Score a whole tree following a function
-		"""
-		#if self.root.label == "R" or self.is_leaf():
-			#print("scoring the %s tree (%s) : " % (self.root.id, self.root.label))
-			#print("----------------")
-			#print("tree " + self.root.id + " content : " + str(len(self.enumerate_nodes())) + " elements")
-			#for e in self.enumerate_nodes():
-			#	if self.is_leaf():
-			#		print(self)
-			#	else :
-			#		print(hashlib.md5(str(e).encode('utf-8')).hexdigest())
-		
-		statuses = []
+	def score_tree_recursive(self, fn: TreeScoring = def_tree_fn()) -> bool:
+		"""Recursive version of ``score_tree`` kept for benchmarking."""
 		if self.is_leaf():
-			self.meta['score'] = fn(self)
-			trace("score[ " + str(self) + " ] = " + str(fn(self)), 3)
-			return True
-		else :
-			for (child, modality) in self.children:
-				statuses.append(child.score_tree(fn))
-			self.meta['score'] = fn(self)
-			trace("score[ " + str(self) + " ] = " + str(fn(self)), 3)
-			return not False in statuses
+		        self.meta['score'] = fn(self)
+		        trace("score[ " + str(self) + " ] = " + str(fn(self)), 3)
+		        return True
+		else:
+		        statuses = [child.score_tree_recursive(fn) for (child, modality) in self.children]
+		        self.meta['score'] = fn(self)
+		        trace("score[ " + str(self) + " ] = " + str(fn(self)), 3)
+		        return not False in statuses
+
+	def score_tree(self, fn: TreeScoring = def_tree_fn()) -> bool:
+		"""Iterative version of ``score_tree``."""
+		stack = [(self, False)]
+		while stack:
+		        node, visited = stack.pop()
+		        if not visited:
+		                stack.append((node, True))
+		                if not node.is_leaf():
+		                        for (child, modality) in reversed(node.children):
+		                                stack.append((child, False))
+		        else:
+		                node.meta['score'] = fn(node)
+		return True
+	def enumerate_nodes(self, depth_max: int = -1, current_depth: int = 0) -> List[Tuple[Node, int]]:
+		"""Iterative version of ``enumerate_nodes``."""
+		enum = []
+		stack = [(self, current_depth, depth_max)]
+		while stack:
+		        tree, depth, dmax = stack.pop()
+		        enum.append((tree.root, depth))
+		        if not tree.is_leaf() and dmax != 0:
+		                ndmax = dmax - 1
+		                for (child, modality) in reversed(tree.children):
+		                        stack.append((child, depth + 1, ndmax))
+		return enum
+
+
+def iter_dfs(tree: 'Tree'):
+	"""Iterative DFS traversal yielding ``Tree`` objects."""
+	stack = [tree]
+	while stack:
+		node = stack.pop()
+		yield node
+		if not node.is_leaf():
+			for (child, modality) in reversed(node.children):
+				stack.append(child)
+
+
+def iter_bfs(tree: 'Tree'):
+	"""Iterative BFS traversal yielding ``Tree`` objects."""
+	from collections import deque
+	queue = deque([tree])
+	while queue:
+		node = queue.popleft()
+		yield node
+		if not node.is_leaf():
+		        for (child, modality) in node.children:
+		                queue.append(child)
+
+
 

--- a/test/bench/bench_recursion.py
+++ b/test/bench/bench_recursion.py
@@ -1,0 +1,51 @@
+import time
+from scott.structs.graph import Graph
+from scott.structs.node import Node
+from scott.structs.edge import Edge
+
+
+def build_chain(size: int) -> Graph:
+    g = Graph()
+    for i in range(size):
+        g.add_node(Node(str(i), 'N'))
+    for i in range(size - 1):
+        g.add_edge(Edge(str(i), g.V[str(i)], g.V[str(i + 1)]))
+    return g
+
+
+def benchmark(size: int = 300):
+    g = build_chain(size)
+    start = time.perf_counter()
+    t_rec = g.to_tree_recursive('0')
+    rec_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    t_iter = g.to_tree('0')
+    iter_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    t_rec.enumerate_nodes_recursive()
+    enum_rec_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    t_iter.enumerate_nodes()
+    enum_iter_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    t_rec.score_tree_recursive()
+    score_rec_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    t_iter.score_tree()
+    score_iter_time = time.perf_counter() - start
+
+    print("to_tree recursive:", rec_time)
+    print("to_tree iterative:", iter_time)
+    print("enumerate_nodes recursive:", enum_rec_time)
+    print("enumerate_nodes iterative:", enum_iter_time)
+    print("score_tree recursive:", score_rec_time)
+    print("score_tree iterative:", score_iter_time)
+
+
+if __name__ == '__main__':
+    benchmark()


### PR DESCRIPTION
## Summary
- rewrite `Graph.to_tree`, `Tree.enumerate_nodes`, and `Tree.score_tree` to use iterative DFS
- add new BFS/DFS helpers on graphs and trees
- keep recursive versions for benchmarking and create a small benchmark script

## Testing
- `python3 -m compileall -q scott`
- `PYTHONPATH=. python3 test/bench/bench_recursion.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68592c87ace4832fa12ca256a245431d